### PR TITLE
Add the utils package to the build process.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,5 +25,5 @@ dependencies = []
 "Bug Tracker" = "https://github.com/chiahao3/ptyrad/issues"
 
 [tool.setuptools]
-packages = ["ptyrad"]
+packages = ["ptyrad", "ptyrad.utils"]
 package-dir = {"" = "src"}


### PR DESCRIPTION
The `pyproject.toml` is missing the `ptyrad.utils` module. If you do not explicitly specify this module in the "[tools.setuptools]" section then it will not be available for regular `pip` installs.

You suggest to install using `pip install -e .` which is why this was not caught originally (utils will still exist in the src folder). 

Adding this line will allow installation by `pip install .` and makes packaging easier in the future.